### PR TITLE
Minor modification to dockerfile to make smaller docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM golang:1.12.4-alpine3.9
-
-RUN mkdir /app
-COPY main.go /app/main.go
+FROM golang:1.12.4-alpine3.9 as hw-builder
+LABEL stage=hw-builder
 WORKDIR /app
+COPY main.go /app/main.go
 
-ENTRYPOINT go run main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -o main
+
+FROM scratch
+COPY --from=hw-builder /app/main .
+ENTRYPOINT [ "/main" ]

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ For more information, see the blog post, ["Easy End-to-End Testing with Cypress.
 The example application is called Sentimentalyzer, a very rudimentary text sentiment analyzer. To run it, enter the following commands:
 
 ```bash
-docker build --tag sentimentalyzer .
-docker run \
+docker build --tag sentimentalyzer . && docker image prune -f --filter label=stage=hw-builder
+docker run -d\
+  --name="cypress-hw" \
   --interactive \
   --tty \
   --env PORT=8999 \
@@ -37,9 +38,9 @@ When the command completes, you will see test output on the console and a video 
 
 This repo contains several branches to demonstrate different Cypress scenarios:
 
-| Scenario | Branch |
-|----------|---------|
-| [Basic Cypress example](https://github.com/mtlynch/hello-world-cypress) | [`master`](https://github.com/mtlynch/hello-world-cypress) |
-| [Using Cypress with Chrome browser](https://github.com/mtlynch/hello-world-cypress/tree/chrome) | [`chrome`](https://github.com/mtlynch/hello-world-cypress/tree/chrome) |
+| Scenario                                                                                            | Branch                                                                 |
+| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| [Basic Cypress example](https://github.com/mtlynch/hello-world-cypress)                             | [`master`](https://github.com/mtlynch/hello-world-cypress)             |
+| [Using Cypress with Chrome browser](https://github.com/mtlynch/hello-world-cypress/tree/chrome)     | [`chrome`](https://github.com/mtlynch/hello-world-cypress/tree/chrome) |
 | [Running Cypress from within Circle CI](https://github.com/mtlynch/hello-world-cypress/tree/circle) | [`circle`](https://github.com/mtlynch/hello-world-cypress/tree/circle) |
 | [Running Cypress from within Travis CI](https://github.com/mtlynch/hello-world-cypress/tree/travis) | [`travis`](https://github.com/mtlynch/hello-world-cypress/tree/travis) |


### PR DESCRIPTION
Awesome example :)
Just one minor suggestion: the resulting docker image is about 350MB, which for a simple hello world program is a lot. 
This PR 
- uses [multistage build](https://docs.docker.com/develop/develop-images/multistage-build/) feature of docker, to reduce the docker image size from 350 MB to about 10 MB 
- deletes the resulting builder image