### PR TITLE
Cypress open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Cypress Artifacts
 e2e/cypress/screenshots/
 e2e/cypress/videos/
+e2e/cypress/fixtures/

--- a/e2e/cypress/integration/spec.js
+++ b/e2e/cypress/integration/spec.js
@@ -9,7 +9,7 @@ it('detects angry sentiment', () => {
     .should('contain', 'You are feeling: Angry')
 })
 
-it('detects content sentiment', () => {
+it('detects content sentiment 😁', () => {
   cy.visit('/analyze')
 
   cy.get('#feelings')

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -5,7 +5,11 @@ services:
     environment:
       - PORT=8123
   cypress:
-    image: "mtlynch/cypress:3.2.0"
+    image: "cypress/included:3.2.0"
+    # pass custom command to start Cypress
+    # otherwise it will use the entrypoint
+    # specified in the Cypress Docker image
+    entrypoint: cypress open
     depends_on:
       - sentimentalyzer
     environment:

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -5,15 +5,31 @@ services:
     environment:
       - PORT=8123
   cypress:
+    # the Docker image to use from https://github.com/cypress-io/cypress-docker-images
     image: "cypress/included:3.2.0"
-    # pass custom command to start Cypress
-    # otherwise it will use the entrypoint
-    # specified in the Cypress Docker image
-    entrypoint: cypress open
+    # pass custom command to start Cypress otherwise it will use the entrypoint
+    # specified in the Cypress Docker image.
+    # also pass "--project <folder>" so that when Cypress opens
+    # it can find file "cypress.json" and show integration specs
+    # https://on.cypress.io/command-line#cypress-open
+    entrypoint: cypress open --project /e2e
     depends_on:
       - sentimentalyzer
     environment:
       - CYPRESS_baseUrl=http://sentimentalyzer:8123
+      # pass environment variable DISPLAY if you need
+      # to show Cypress GUI on the host system
+      # typically you get the IP of the host system
+      # and set DISPLAY
+      #   IP=$(ifconfig en0 | grep inet | awk '$1=="inet" {print $2}')
+      #   DISPLAY=$IP:0
+      # run docker-compose with
+      #   DISPLAY=$IP:0 docker-compose up --exit-code-from cypress
+      - DISPLAY
     working_dir: /e2e
     volumes:
       - ./:/e2e
+      # allow connecting from Docker container to
+      # external XVFB server running on the host machine
+      # see https://sourabhbajaj.com/blog/2017/02/07/gui-applications-docker-mac/
+      - /tmp/.X11-unix:/tmp/.X11-unix


### PR DESCRIPTION
I have installed XQuartz XVFB server on Mac (https://sourabhbajaj.com/blog/2017/02/07/gui-applications-docker-mac/) and got "cypress open" to run inside the Docker container while seeing (and interacting) it on the desktop.

<img width="1301" alt="Screen Shot 2019-05-01 at 5 26 06 PM" src="https://user-images.githubusercontent.com/2212006/57044711-6ed68900-6c39-11e9-913e-5b3a7bd26087.png">

I am not sure how you would execute `cypress run` vs `cypress open` though, but for people who don't want to install anything, yet have interactive Cypress GUI this is a good way to work with tests.