### PR TITLE
minor README improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To execute the end-to-end tests for Sentimentalyzer, enter the following command
 
 ```bash
 cd e2e
-docker-compose up --exit-code-from cypress
+docker-compose up --exit-code-from --abort-on-container-exit cypress
 ```
 
 When the command completes, you will see test output on the console and a video of the test run will appear in the folder `e2e/cypress/integration/videos`.


### PR DESCRIPTION
```
> docker-compose -f docker-compose.yml -f cy-open.yml up --exit-code-from cypress
WARNING: using --exit-code-from implies --abort-on-container-exit
Creating network "e2e_default" with the default driver
Building sentimentalyzer
Step 1/5 : FROM golang:1.12.4-alpine3.9
1.12.4-alpine3.9: Pulling from library/golang
bdf0201b3a05: Pull complete
```

Including both `--exit-code-from` and `--abort-on-container-exit` avoids the warning from Docker.