### PR TITLE
docker bug requires arguments in specific order

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To execute the end-to-end tests for Sentimentalyzer, enter the following command
 
 ```bash
 cd e2e
-docker-compose up --exit-code-from --abort-on-container-exit cypress
+docker-compose up --abort-on-container-exit --exit-code-from cypress
 ```
 
 When the command completes, you will see test output on the console and a video of the test run will appear in the folder `e2e/cypress/integration/videos`.


### PR DESCRIPTION
at least "Docker version 20.10.18, build b40c2f6" (released 2022-09-09) requires argument `--abort-on-container-exit` BEFORE argument `--exit-code-from` - otherwise it will complain that the container "--abort-on-container-exit was not found"

it's probably just a docker-compose bug that ideally should be fixed upstream, but in the meantime, lets avoid the bug/issue here.

quote:
```
root@devad22:/home/hans/projects/easyad/hello-world-cypress/e2e# docker --version
Docker version 20.10.18, build b40c2f6
root@devad22:/home/hans/projects/easyad/hello-world-cypress/e2e# docker-compose up --exit-code-from --abort-on-container-exit cypress;
WARNING: using --exit-code-from implies --abort-on-container-exit
ERROR: No service named "--abort-on-container-exit" was found in your compose file.
ERROR: 2
root@devad22:/home/hans/projects/easyad/hello-world-cypress/e2e# docker-compose up --abort-on-container-exit --exit-code-from cypress;
Starting e2e_sentimentalyzer_1 ... done
Starting e2e_cypress_1         ... done
Attaching to e2e_sentimentalyzer_1, e2e_cypress_1
sentimentalyzer_1  | 2022/09/12 13:41:30 Listening on port 8123
^C
```